### PR TITLE
fix bug with imbalance when paying gas

### DIFF
--- a/srml/contract/src/tests.rs
+++ b/srml/contract/src/tests.rs
@@ -26,7 +26,7 @@ fn check_reward_per_share() {
         assert_eq!(Kton::reward_can_withdraw(&11), 2600);
         let new_free_balance = free_balance + 900;
         assert_eq!(Ring::free_balance(&11), new_free_balance);
-        assert_eq!(Ring::total_issuance(), ring_total_issuance + 900);
+        assert_eq!(Ring::total_issuance(), ring_total_issuance - 100);
 
 
     });


### PR DESCRIPTION
**Bug description**
After interacting with the contract module, paying gas does not reduce total_issuance of RING, instead, it rises.

**Causes**
when consuming RING from kton shares, actually we are consuming the balance on `sys_account`, but we don't handle imbalance with that.

**Fixes**
handle imbalance when consuming RING balance of `sys_account`

